### PR TITLE
create swapchain_config with default window size

### DIFF
--- a/wsi/src/lib.rs
+++ b/wsi/src/lib.rs
@@ -163,28 +163,33 @@ where
         log::info!("Surface capabilities: {:#?}. Pick {} images", capabilities.image_count, image_count);
         assert!(capabilities.usage.contains(usage), "Surface supports {:?}, but {:?} was requested");
 
-        let hidpi_factor = self.window.get_hidpi_factor();
-        let (window_width, window_height) = self.window
-            .get_inner_size()
-            .unwrap()
-            .to_physical(hidpi_factor)
-            .into();
+        let extent = capabilities.current_extent.unwrap_or({
+            let hidpi_factor = self.window.get_hidpi_factor();
+            let start = capabilities.extents.start;
+            let end = capabilities.extents.end;
+            let (window_width, window_height) = self.window
+                .get_inner_size()
+                .unwrap()
+                .to_physical(hidpi_factor)
+                .into();
+            gfx_hal::window::Extent2D {
+                width: end.width.min(start.width.max(window_width)),
+                height: end.height.min(start.height.max(window_height)),
+            }
+        });
 
-        let default_extent = gfx_hal::window::Extent2D {
-            width: window_width,
-            height: window_height,
-        };
-
-        let mut swap_config = gfx_hal::window::SwapchainConfig::from_caps(&capabilities, format, default_extent);
-        swap_config.present_mode = present_mode;
-        swap_config.image_count = image_count;
-        swap_config.image_usage = usage;
-
-        log::info!("Swap Config: {:#?}", swap_config);
-
-        let extent = swap_config.extent.clone();
-
-        let (swapchain, backbuffer) = device.create_swapchain(&mut self.raw, swap_config, None)?;
+        let (swapchain, backbuffer) = device.create_swapchain(
+            &mut self.raw,
+            gfx_hal::SwapchainConfig {
+                present_mode,
+                format,
+                extent,
+                image_count,
+                image_layers: 1,
+                image_usage: usage,
+            },
+            None,
+        )?;
 
         Ok(Target {
             relevant: relevant::Relevant,


### PR DESCRIPTION
On Wayland (using the gfx vulkan backend) `capabilities.current_extent` can be `None`, which causes [this unwrap](https://github.com/rustgd/rendy/blob/8eecae13a3c75e927e412b074b27e2521e8316a5/wsi/src/lib.rs#L171) to fail.

Looking at https://github.com/gfx-rs/gfx/issues/2421#issuecomment-423852078 and https://github.com/gfx-rs/gfx/pull/2484 the solution seems to be to default to the window dimensions (which `SwapchainConfig::from_caps` does)