### PR TITLE
Fix some typos

### DIFF
--- a/README.md
+++ b/README.md
@@ -86,7 +86,7 @@ Similar `ComputePipeline` trait exists for compute pipelines.
 #### Example
 
 ```rust
-#[derive(DescritorSet)]
+#[derive(DescriptorSet)]
 struct Example {
     /// This field will be associated with binding 1 of type `VK_DESCRIPTOR_TYPE_UNIFORM_BUFFER`.
     /// Actual `Buffer` will be allocated and kept updated by `Set<Example>`.
@@ -108,7 +108,7 @@ struct Example {
 
 ### Shader reflection - ***Not yet implemented***
 
-`rendy` will use `spirv-relfect` or similiar crate to read layout information directly from shaders
+`rendy` will use `spirv-reflect` or similiar crate to read layout information directly from shaders
 and use it to automatically populate descriptors and set index/vertex buffers based on registered data sources.
 
 ### Modularity


### PR DESCRIPTION
Just noticed a couple typos while reading the readme.